### PR TITLE
fix: scientific notation is now correctly handled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "svg-path-parser"
 description = "Generate a list of points from SVG path strings"
 repository = "https://github.com/UnicodingUnicorn/svg-path-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [ "UnicodingUnicorn" ]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,20 @@ impl<'a> PathParser<'a> {
                 break;
             }
         }
-        
+
+        // Handle scientific notation (1.23e45)
+        if let Some(ch) = self.data.next_if_eq(&'e') {
+            s.push(ch);
+
+            if let Some(ch) = self.data.next_if(|ch| matches!(ch, '-' | '+')) {
+                s.push(ch)
+            }
+
+            while let Some(ch) = self.data.next_if(|ch| ch.is_ascii_digit()) {
+                s.push(ch)
+            }
+        }
+
         s.parse::<f64>().ok()
     }
 


### PR DESCRIPTION
closes #1